### PR TITLE
add crc32 function

### DIFF
--- a/src/Zlib.jl
+++ b/src/Zlib.jl
@@ -3,7 +3,7 @@ module Zlib
 
 import Base: read, write, close, eof
 
-export compress, decompress
+export compress, decompress, crc32
 
 const Z_NO_FLUSH      = 0
 const Z_PARTIAL_FLUSH = 1
@@ -353,5 +353,13 @@ end
 
 decompress(input::String, raw::Bool=false) = decompress(convert(Vector{Uint8}, input), raw)
 
+
+function crc32(data::Vector{Uint8}, crc::Integer=0)
+    uint32(ccall((:crc32, libz),
+                 Culong, (Culong, Ptr{Uint8}, Cuint),
+                 crc, data, length(data)))
+end
+
+crc32(data::String, crc::Integer=0) = crc32(convert(Vector{Uint8}, data), crc)
 
 end # module

--- a/test/test.jl
+++ b/test/test.jl
@@ -66,3 +66,11 @@ for x in data
     end
 end
 close(r)
+
+
+@test crc32("") == 0
+@test crc32("hello") == 0x3610a686
+@test crc32("Julia programming language") == 0xfc485364
+crc = crc32("Julia programming")
+@test crc == 0xc7db4271
+@test crc32(" language", crc) == 0xfc485364


### PR DESCRIPTION
This function is about 26x faster than the native julia implementation I wrote
in the CRC32 package (https://github.com/fhs/CRC32.jl). I wish I knew zlib had
crc32 before, but it doesn't hurt to have both implementations available in
case we don't want to depend on libz.

Best timing out of 5 runs:

```
julia> data = rand(Uint8, 10^8);

julia> @time CRC32.crc32(data)
elapsed time: 4.949734025 seconds (1599999776 bytes allocated)
0x9b716e0b

julia> @time Zlib.crc32(data)
elapsed time: 0.189449411 seconds (64 bytes allocated)
0x9b716e0b
```
