### PR TITLE
Fix ambiguity and most of the deprecation warnings on master

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ follows.
 ### Basic API
 
 ```julia
-# Compress data, ouputting a Vector{Uint8} where data is either a Vector{Uint8}
-# or a String.
+# Compress data, ouputting a Vector{UInt8} where data is either a Vector{UInt8}
+# or a AbstractString.
 compress(data)
 
 # Compress at a particular level in [1, 9]
 compress("Hello world", 5)
 
-# Decompress to a Vector{Uint8} where data is either a Vector{Uint8} or a
-# String.
+# Decompress to a Vector{UInt8} where data is either a Vector{UInt8} or a
+# AbstractString.
 decompress(data)
 ```
 
@@ -47,8 +47,8 @@ Writer(io::IO, level::Integer, gzip::Bool=false, raw::Bool=false)
 
 ### crc32
 
-`crc32(data::Vector{Uint8}, crc::Integer=0)`
-`crc32(data::String, crc::Integer=0)`
+`crc32(data::Vector{UInt8}, crc::Integer=0)`
+`crc32(data::AbstractString, crc::Integer=0)`
 
 Compute and return the 32-bit cycle redundancy check on `data`, updating a
 running value `crc`.
@@ -60,5 +60,3 @@ crc32("hello")
 ```
 0x3610a686
 ```
-
-

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.3
+Compat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Base.Test
 using Zlib
 
-data = convert(Vector{Uint8}, rand(1:255, 1000000))
+data = convert(Vector{UInt8}, rand(1:255, 1000000))
 decompressed = decompress(compress(data))
 @test data == decompressed
 
@@ -23,25 +23,25 @@ seekstart(b)
 
 seekstart(b)
 r = Zlib.Reader(b)
-decompressed = Array(Uint8, 0)
+decompressed = Array(UInt8, 0)
 while !eof(r)
-    append!(decompressed, read(r, Uint8, 200000))
+    append!(decompressed, read(r, UInt8, 200000))
 end
 @test data == decompressed
 
 
-data = {
-    convert(Uint8, 20),
+data = Any[
+    convert(UInt8, 20),
     42,
     float(3.14),
     "julia",
     rand(5),
     rand(3, 4),
-    sub(rand(10,10), 2:8,2:4),
-}
+    sub(rand(10,10), 2:8,2:4)
+]
 
 b = IOBuffer()
-@test_throws ErrorException read(w, Uint8, 1)
+@test_throws ErrorException read(w, UInt8, 1)
 w = Zlib.Writer(b)
 for x in data
     write(w, x)
@@ -50,10 +50,10 @@ close(w)
 
 seekstart(b)
 r = Zlib.Reader(b)
-@test_throws ErrorException write(r, convert(Uint8, 20))
+@test_throws ErrorException write(r, convert(UInt8, 20))
 for x in data
     if typeof(x) == ASCIIString
-        @test x == ASCIIString(read(r, Uint8, length(x)))
+        @test x == ASCIIString(read(r, UInt8, length(x)))
     elseif typeof(x) <: Array
         y = similar(x)
         y[:] = 0


### PR DESCRIPTION
The only deprecation warningleft is for `cartesianmap`. Fixing on master/0.4 should be easy but I'm not sure if there's a compatibility layer for that yet.