### PR TITLE
Bumped minimal version to Julia 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ os:
     - osx
     - linux
 julia:
+    - 0.5
+    - 0.6
     - nightly
-    - 0.4
-    - 0.3
 notifications:
     email: false
 #script:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.3
-Compat 0.8.4
+julia 0.5
+Compat 0.9.5

--- a/src/Zlib.jl
+++ b/src/Zlib.jl
@@ -136,7 +136,7 @@ Writer(io::IO, gzip::Bool=false, raw::Bool=false) = Writer(io, 9, gzip, raw)
 function write(w::Writer, p::Ptr, nb::Integer)
     w.strm.next_in = p
     w.strm.avail_in = nb
-    outbuf = Array(UInt8, 1024)
+    outbuf = Array{UInt8}(1024)
 
     while true
         w.strm.avail_out = length(outbuf)
@@ -208,10 +208,10 @@ function close(w::Writer)
     w.closed = true
 
     # flush zlib buffer using Z_FINISH
-    inbuf = Array(UInt8, 0)
+    inbuf = Array{UInt8}(0)
     w.strm.next_in = pointer(inbuf)
     w.strm.avail_in = 0
-    outbuf = Array(UInt8, 1024)
+    outbuf = Array{UInt8}(1024)
     ret = Z_OK
     while ret != Z_STREAM_END
         w.strm.avail_out = length(outbuf)
@@ -239,7 +239,7 @@ function compress(input::Vector{UInt8}, level::Integer, gzip::Bool=false, raw::B
     w = Writer(b, level, gzip, raw)
     write(w, input)
     close(w)
-    takebuf_array(b)
+    take!(b)
 end
 
 
@@ -284,7 +284,7 @@ function fillbuf(r::Reader, minlen::Integer)
         input = read(r.io, UInt8, min(nb_available(r.io), r.bufsize))
         r.strm.next_in = pointer(input)
         r.strm.avail_in = length(input)
-        #outbuf = Array(UInt8, r.bufsize)
+        #outbuf = Array{UInt8}(r.bufsize)
 
         while true
             #r.strm.next_out = outbuf
@@ -367,7 +367,7 @@ function readuntil(r::Reader, delim::UInt8)
         nb = search(r.buf, delim) #, offset)
     end
     if nb == 0;  nb == nb_available(r.buf); end
-    read!(r.buf, Array(UInt8, nb))
+    read!(r.buf, Array{UInt8}(nb))
 end
 
 function close(r::Reader)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,7 @@ seekstart(b)
 
 seekstart(b)
 r = Zlib.Reader(b)
-decompressed = Array(UInt8, 0)
+decompressed = Array{UInt8}(0)
 while !eof(r)
     append!(decompressed, read(r, UInt8, 200000))
 end
@@ -53,8 +53,8 @@ seekstart(b)
 r = Zlib.Reader(b)
 @test_throws ErrorException write(r, convert(UInt8, 20))
 for x in data
-    if isa(x, Compat.ASCIIString)
-        @test x == Compat.ASCIIString(read(r, UInt8, length(x)))
+    if isa(x, String)
+        @test x == String(read(r, UInt8, length(x)))
     elseif isa(x, Array)
         y = similar(x)
         y[:] = 0


### PR DESCRIPTION
I know Libz.jl should be preferred to Zlib.jl these days, but some packages still depend on it and it's much easier to update this package to Julia 0.6 than to rewrite dependent code. See [this discussion](https://discourse.julialang.org/t/the-poor-state-of-fileformats-for-high-performance-computing/5326) for more details.

I pushed minimal Julia version straight to 0.6. The previous was 0.3 which seems to be veeery outdated, but if you mean to support something in between (e.g. Julia 0.5), let me know and I will test it as well. 